### PR TITLE
Add emotion-based AR viewer scenes

### DIFF
--- a/src/app/features/ar-viewer/ar-viewer.component.html
+++ b/src/app/features/ar-viewer/ar-viewer.component.html
@@ -9,9 +9,7 @@
   <video id="video" autoplay playsinline muted class="invisible absolute inset-0 w-full h-full object-cover"></video>
 
   <!-- Audio de fondo -->
-  <audio id="backgroundAudio" preload="auto" playsinline>
-    <source src="assets/audio/Ansiedad1.mp3" type="audio/mpeg" />
-  </audio>
+  <audio id="backgroundAudio" preload="auto" playsinline></audio>
 
   <!-- Botón para activar sonido (sin *ngIf para evitar CommonModule) -->
  

--- a/src/app/features/ar-viewer/ar-viewer.component.ts
+++ b/src/app/features/ar-viewer/ar-viewer.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, AfterViewInit, OnDestroy } from '@angular/core';
 import { Location } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
 import * as THREE from 'three';
 
 declare var SelfieSegmentation: any;
@@ -40,23 +41,32 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
   private unlockAudioBound?: () => void;
   public hideEnableButton = false; // para ocultar botón tras habilitar sonido
 
-  constructor(private location: Location) {}
+  private emotion: string = 'ansiedad';
+
+  constructor(private location: Location, private route: ActivatedRoute) {}
 
   ngOnInit(): void {
     // No tocar DOM aquí
   }
 
   ngAfterViewInit(): void {
-    setTimeout(() => {
-      this.initializeElements();
-      this.initThreeJS360();
-      this.startCamera().then(() => {
-        this.initMediaPipe();
-        this.processFrame();
-      }).catch(err => {
-        console.error('Error al inicializar la cámara:', err);
-      });
-    }, 100);
+    this.route.queryParams.subscribe(params => {
+      const emotionParam = params['emotion'];
+      const valid = ['tristeza', 'ansiedad', 'estres'];
+      if (emotionParam && valid.includes(emotionParam)) {
+        this.emotion = emotionParam;
+      }
+      setTimeout(() => {
+        this.initializeElements();
+        this.initThreeJS360();
+        this.startCamera().then(() => {
+          this.initMediaPipe();
+          this.processFrame();
+        }).catch(err => {
+          console.error('Error al inicializar la cámara:', err);
+        });
+      }, 100);
+    });
   }
 
   private initializeElements(): void {
@@ -74,9 +84,7 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     this.canvas.style.pointerEvents = 'none';
 
     // Configurar audio (ruta recomendada en Angular)
-    if (!this.audio.src) {
-      this.audio.src = '/audio/Ansiedad1.mp3';
-    }
+    this.audio.src = this.getAudioForEmotion();
     this.audio.loop = true;
     this.audio.preload = 'auto';
 
@@ -133,7 +141,7 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
     geometry.scale(-1, 1, 1);
 
     const loader = new THREE.TextureLoader();
-    const imageUrl = '/imagenes/img1.jpg'; // ¡importante! usar assets/...
+    const imageUrl = this.getImageForEmotion();
 
     loader.load(
       imageUrl,
@@ -149,6 +157,28 @@ export class ArViewerComponent implements OnInit, AfterViewInit, OnDestroy {
         console.error('Error cargando textura 360°:', error);
       }
     );
+  }
+
+  private getAudioForEmotion(): string {
+    switch (this.emotion) {
+      case 'tristeza':
+        return '/audio/depresion1.mp3';
+      case 'estres':
+        return '/audio/Estres2.mp3';
+      default:
+        return '/audio/Ansiedad1.mp3';
+    }
+  }
+
+  private getImageForEmotion(): string {
+    switch (this.emotion) {
+      case 'tristeza':
+        return '/imagenes/depresion.png';
+      case 'estres':
+        return '/imagenes/Estres.jpg';
+      default:
+        return '/imagenes/Ansiedad.jpg';
+    }
   }
 
   private addInteractionControls(): void {

--- a/src/app/features/generar-chat/generar-chat.component.ts
+++ b/src/app/features/generar-chat/generar-chat.component.ts
@@ -33,8 +33,15 @@ export class GenerarChatComponent implements OnInit {
 
   onSubmit(): void {
     if (this.prompt.trim()) {
+      const detected = this.detectEmotion(this.prompt);
       // Agregar mensaje del usuario al array de mensajes
       this.messages.push({ sender: 'user', text: this.prompt });
+
+      if (detected) {
+        this.openAR(detected);
+        this.prompt = '';
+        return;
+      }
 
       // Llamar al servicio para obtener la respuesta del bot
       this.generarChatService.getContent(this.prompt).subscribe(
@@ -67,8 +74,19 @@ export class GenerarChatComponent implements OnInit {
     return match ? match[1] : 'Ejercicio';
   }
 
+  private detectEmotion(text: string): string | null {
+    const lower = text.toLowerCase();
+    const sadness = ['triste', 'tristeza', 'deprimido', 'depresion'];
+    const anxiety = ['ansiedad', 'ansioso', 'nervioso', 'angustia'];
+    const stress = ['estres', 'estresado', 'tension', 'agobiado'];
+    if (sadness.some(k => lower.includes(k))) return 'tristeza';
+    if (anxiety.some(k => lower.includes(k))) return 'ansiedad';
+    if (stress.some(k => lower.includes(k))) return 'estres';
+    return null;
+  }
+
   // Función para abrir el componente de AR
   openAR(exerciseName: string): void {
-    this.router.navigate(['/ar-viewer'], { queryParams: { exercise: exerciseName } });
+    this.router.navigate(['/ar-viewer'], { queryParams: { emotion: exerciseName } });
   }
 }


### PR DESCRIPTION
## Summary
- Detect user emotion from message keywords and route to AR breathing exercise
- Load AR viewer audio and 360 imagery based on emotion query parameter
- Prepare audio tag for dynamic source assignment

## Testing
- `CI=true npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Unknown word in app.component.css)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f7d76f9883239dd18e6fc684e9aa