### PR TITLE
Add emotion-based AR viewer scenes

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -17,4 +17,4 @@
   box-shadow: 0 4px 14px rgba(0,0,0,.15);
 }
 
-.app-main { min-height: calc(100dvh - 56px); }
+.app-main { min-height: calc(100dvh - 56px); }

--- a/src/app/features/ar-viewer/ar-viewer.component.html
+++ b/src/app/features/ar-viewer/ar-viewer.component.html
@@ -9,9 +9,7 @@
   <video id="video" autoplay playsinline muted class="invisible absolute inset-0 w-full h-full object-cover"></video>
 
   <!-- Audio de fondo -->
-  <audio id="backgroundAudio" preload="auto" playsinline>
-    <source src="assets/audio/Ansiedad1.mp3" type="audio/mpeg" />
-  </audio>
+  <audio id="backgroundAudio" preload="auto" playsinline></audio>
 
   <!-- Botón para activar sonido (sin *ngIf para evitar CommonModule) -->
  

--- a/src/app/features/generar-chat/generar-chat.component.ts
+++ b/src/app/features/generar-chat/generar-chat.component.ts
@@ -33,6 +33,8 @@ export class GenerarChatComponent implements OnInit {
 
   onSubmit(): void {
     if (this.prompt.trim()) {
+      const emotion = this.detectEmotion(this.prompt);
+
       // Agregar mensaje del usuario al array de mensajes
       this.messages.push({ sender: 'user', text: this.prompt });
 
@@ -56,6 +58,9 @@ export class GenerarChatComponent implements OnInit {
         }
       );
 
+      // Abrir el visor de AR según la emoción detectada
+      this.openAR(emotion);
+
       // Limpiar el campo de entrada
       this.prompt = '';
     }
@@ -67,8 +72,22 @@ export class GenerarChatComponent implements OnInit {
     return match ? match[1] : 'Ejercicio';
   }
 
+  private detectEmotion(text: string): string {
+    const lower = text.toLowerCase();
+    const sadness = ['triste', 'tristeza', 'deprimido', 'depresion'];
+    const anxiety = ['ansiedad', 'ansioso', 'nervioso', 'angustia'];
+    const stress = ['estres', 'estresado', 'tension', 'agobiado'];
+    if (sadness.some(k => lower.includes(k))) return 'tristeza';
+    if (anxiety.some(k => lower.includes(k))) return 'ansiedad';
+    if (stress.some(k => lower.includes(k))) return 'estres';
+    return 'default';
+  }
+
   // Función para abrir el componente de AR
-  openAR(exerciseName: string): void {
-    this.router.navigate(['/ar-viewer'], { queryParams: { exercise: exerciseName } });
+  openAR(emotion: string): void {
+    const url = this.router.serializeUrl(
+      this.router.createUrlTree(['/ar-viewer'], { queryParams: { emotion } })
+    );
+    window.open(url, '_blank');
   }
 }


### PR DESCRIPTION
## Summary
- Detect keyword-driven emotions while still retrieving friendly chat responses
- Support a default scene and open AR viewer in a new tab based on detected emotion

## Testing
- `CI=true npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Unknown word in app.component.css)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f7d76f9883239dd18e6fc684e9aa